### PR TITLE
Force TLSv1 for all communication

### DIFF
--- a/client/sguil.tk
+++ b/client/sguil.tk
@@ -248,7 +248,7 @@ proc ConnectToSguild {} {
         return -code error "Error: Unable to load TLS: $tmpError"
     }
 
-    tls::import $socketID
+    tls::import $socketID -ssl2 false -ssl3 false -tls1 true
 
     after 1000
     if {$DEBUG} {puts "Sending PING"}

--- a/contrib/quickscript.tcl
+++ b/contrib/quickscript.tcl
@@ -173,7 +173,7 @@ if { $serverVersion != $VERSION } {
 SendToSguild $socketID [list VersionInfo $VERSION]
 
 # SSL-ify the socket
-if { [catch {tls::import $socketID} tlsError] } { 
+if { [catch {tls::import $socketID -ssl2 false -ssl3 false -tls1 true} tlsError] } {
 
     puts "failed."
     puts "ERROR: $tlsError"

--- a/sensor/contrib/ossec_agent/ossec_agent.tcl
+++ b/sensor/contrib/ossec_agent/ossec_agent.tcl
@@ -397,7 +397,7 @@ proc ConnectToSguilServer {} {
         }
 
         catch { flush $sguildSocketID }
-        if {$OPENSSL} { tls::import $sguildSocketID }
+        if {$OPENSSL} { tls::import $sguildSocketID  -ssl2 false -ssl3 false -tls1 true}
 
         set CONNECTED 1
         if {$DEBUG} {puts "Connected to $SERVER_HOST"}

--- a/sensor/example_agent.tcl
+++ b/sensor/example_agent.tcl
@@ -292,7 +292,7 @@ proc ConnectToSguilServer {} {
         }
 
         catch { flush $sguildSocketID }
-        tls::import $sguildSocketID
+        tls::import $sguildSocketID -ssl2 false -ssl3 false -tls1 true
 
         set CONNECTED 1
         if {$DEBUG} {puts "Connected to $SERVER_HOST"}

--- a/sensor/pads_agent.tcl
+++ b/sensor/pads_agent.tcl
@@ -233,7 +233,7 @@ proc ConnectToSguilServer {} {
         }
 
         catch { flush $sguildSocketID }
-        tls::import $sguildSocketID
+        tls::import $sguildSocketID -ssl2 false -ssl3 false -tls1 true
 
         fileevent $sguildSocketID readable [list SguildCmdRcvd $sguildSocketID]
         set CONNECTED 1

--- a/sensor/pcap_agent-sancp.tcl
+++ b/sensor/pcap_agent-sancp.tcl
@@ -579,7 +579,7 @@ proc ConnectToSguilServer {} {
         }
 
         catch { flush $sguildSocketID }
-        tls::import $sguildSocketID
+        tls::import $sguildSocketID -ssl2 false -ssl3 false -tls1 true
 
         fileevent $sguildSocketID readable [list SguildCmdRcvd $sguildSocketID]
         set CONNECTED 1

--- a/sensor/pcap_agent.tcl
+++ b/sensor/pcap_agent.tcl
@@ -120,7 +120,7 @@ proc UploadRawFile { fileName TRANS_ID fileSize } {
         }
 
         catch { flush $dataChannelID }
-        tls::import $dataChannelID
+        tls::import $dataChannelID -ssl2 false -ssl3 false -tls1 true
 
         #
         # Connected and version checks finished.
@@ -605,7 +605,7 @@ proc ConnectToSguilServer {} {
         }
 
         catch { flush $sguildSocketID }
-        tls::import $sguildSocketID
+        tls::import $sguildSocketID -ssl2 false -ssl3 false -tls1 true
 
         fileevent $sguildSocketID readable [list SguildCmdRcvd $sguildSocketID]
         set CONNECTED 1

--- a/sensor/sancp_agent.tcl
+++ b/sensor/sancp_agent.tcl
@@ -183,7 +183,7 @@ proc UploadSancpFile { filePath fileSize } {
         }
 
         catch { flush $dataChannelID }
-        tls::import $dataChannelID
+        tls::import $dataChannelID -ssl2 false -ssl3 false -tls1 true
 
         #
         # Connected and version checks finished.

--- a/sensor/sensor_agent.tcl
+++ b/sensor/sensor_agent.tcl
@@ -973,7 +973,7 @@ proc ConnectToSguilServer {} {
     }
     flush $sguildSocketID
     if {$OPENSSL} {
-      tls::import $sguildSocketID
+      tls::import $sguildSocketID -ssl2 false -ssl3 false -tls1 true
     }
     fileevent $sguildSocketID readable [list SguildCmdRcvd $sguildSocketID]
     set CONNECTED 1

--- a/sensor/snort_agent.tcl
+++ b/sensor/snort_agent.tcl
@@ -491,7 +491,7 @@ proc ConnectToSguilServer {} {
         }
 
         catch { flush $sguildSocketID }
-        tls::import $sguildSocketID
+        tls::import $sguildSocketID -ssl2 false -ssl3 false -tls1 true
 
         fileevent $sguildSocketID readable [list SguildCmdRcvd $sguildSocketID]
         set CONNECTED 1

--- a/server/lib/SguildConnect.tcl
+++ b/server/lib/SguildConnect.tcl
@@ -78,7 +78,7 @@ proc ClientVersionCheck { socketID clientVersion } {
     return
   }
 
-  if { [catch {tls::import $socketID -server true -keyfile $KEY -certfile $PEM} importError] } {
+  if { [catch {tls::import $socketID -server true -keyfile $KEY -certfile $PEM -ssl2 false -ssl3 false -tls1 true} importError] } {
         LogMessage "ERROR: $importError"
         close $socketID
         ClientExitClose $socketID
@@ -132,7 +132,7 @@ proc AgentVersionCheck { socketID agentVersion } {
     return
   }
 
-  if { [catch {tls::import $socketID -server true -keyfile $KEY -certfile $PEM} importError] } {
+  if { [catch {tls::import $socketID -server true -keyfile $KEY -certfile $PEM -ssl2 false -ssl3 false -tls1 true} importError] } {
         LogMessage "ERROR: $importError"
         catch {close $socketID}
         CleanUpDisconnectedAgent $socketID

--- a/server/xscriptd
+++ b/server/xscriptd
@@ -365,7 +365,7 @@ proc ClientConnect { socketID IPAddr port } {
     return
   }
   if {$OPENSSL} {
-    tls::import $socketID -server true -keyfile $KEY -certfile $PEM
+    tls::import $socketID -server true -keyfile $KEY -certfile $PEM -ssl2 false -ssl3 false -tls1 true
     fileevent $socketID readable [list HandShake $socketID ClientCmdRcvd]
   } else {
     fileevent $socketID readable [list ClientCmdRcvd $socketID]


### PR DESCRIPTION
This patch explicitly disables SSLv2 and SSLv3, and enables TLSv1 in
sensor-server and client-server communications.

SSLv2 clearly shouldn't be used anymore. While changing this code it
makes sense to skip SSLv3 as well.

Other than the improvement of security, this solves a problem with
sguild running on Debian Wheezy. It appears that tcl-tls on that OS
no longer supports SSLv2. Clients/agents connecting to this sguild
instance are rejected with an error:
    ERROR: handshake failed: wrong version number

Forcing both sides to SSLv3 or TLSv1 solves this issue. This patch
chooses to force to TLSv1.

All clients, agents and the server will need to be in sync for this
to work properly, so it may be a good time to also bump the protocol
version number.
