### PR TITLE
Fixed reverse DNS lookup bug.

### DIFF
--- a/client/lib/extdata.tcl
+++ b/client/lib/extdata.tcl
@@ -483,7 +483,7 @@ proc GetHostbyAddr { ip } {
     # Wait for the request to finish
     catch {dns::wait $tok}
 
-    if [catch {[dns::name $tok]} hostname] { set hostname "Unknown" }
+    if [catch {dns::name $tok} hostname] { set hostname "Unknown" }
     dns::cleanup $tok
     if { $hostname == "" } { set hostname "Unknown" }
     return $hostname


### PR DESCRIPTION
An extra [] caused reverse DNS lookups to fail, as tcl tried to evaluate
the returned hostname as a tcl script... Could be exploitable if some sets
their revese to something that is valid tcl-code.