### PR TITLE
Add comment in autocat.conf to use autocat builder

### DIFF
--- a/server/autocat.conf
+++ b/server/autocat.conf
@@ -1,7 +1,7 @@
-#############################################################################################################
-# This file is no longer used to process autocats, as autocat information is now stored in securityonion_db.#
-# If you would like to add autocats, please do so via the autocat builder in the Sguil client.              #
-#############################################################################################################
+####################################################################################################################
+# This file is no longer used to process autocat rules, as autocat information is now stored in the Sguil database.#
+# If you would like to add new autocat rules, please do so via the autocat builder in the Sguil client.            #
+####################################################################################################################
 #
 # $Id: autocat.conf,v 1.9 2005/02/10 19:51:37 bamm Exp $ #
 #

--- a/server/autocat.conf
+++ b/server/autocat.conf
@@ -1,3 +1,8 @@
+#############################################################################################################
+# This file is no longer used to process autocats, as autocat information is now stored in securityonion_db.#
+# If you would like to add autocats, please do so via the autocat builder in the Sguil client.              #
+#############################################################################################################
+#
 # $Id: autocat.conf,v 1.9 2005/02/10 19:51:37 bamm Exp $ #
 #
 # This file is read by sguild on start up. It's contents


### PR DESCRIPTION
Now that autocat information is stored in the Sguil database, it would be nice to have a comment in autocat.conf to point the user towards the autocat builder in the Sguil client for adding autocat rules.

Ex.
"This file is no longer used to process autocat rules, as autocat information is now stored in the Sguil database.
If you would like to add new autocat rules, please do so via the autocat builder in the Sguil client." 

Thanks,
Wes