### PR TITLE
added output runtime flag for tcpflow

### DIFF
--- a/server/lib/SguildTranscript.tcl
+++ b/server/lib/SguildTranscript.tcl
@@ -290,7 +290,7 @@ proc XscriptDebugMsg { TRANS_ID msg } {
 }
 
 proc GenerateXscript { fileName clientSocketID winName TRANS_ID } {
-  global transInfoArray TCPFLOW LOCAL_LOG_DIR P0F P0F_PATH CANCEL_TRANS_FLAG
+  global transInfoArray TCPFLOW LOCAL_LOG_DIR P0F P0F_PATH CANCEL_TRANS_FLAG TMPDATADIR
   set NODATAFLAG 1
   # We don't have a really good way for make xscripts yet and are unable
   # to figure out the true src. So we assume the low port was the server
@@ -321,7 +321,7 @@ proc GenerateXscript { fileName clientSocketID winName TRANS_ID } {
     }
   }
   catch {SendSocket $clientSocketID [list XscriptMainMsg $winName " "]}
-  if  [catch {open "| $TCPFLOW -c -r $fileName"} tcpflowID] {
+  if  [catch {open "| $TCPFLOW -c -r $fileName -o $TMPDATADIR"} tcpflowID] {
     LogMessage "ERROR: tcpflow: $tcpflowID"
     catch {SendSocket $clientSocketID [list XscriptDebugMsg $winName "ERROR: tcpflow: $tcpflowID"]}
     catch {close $tcpflowID}


### PR DESCRIPTION
tcpflow by default outputs at a minimum report.xml.
the default directory for the output is ./. when running as a nonroot
user this will cause tcpflow to error trying to write out report.xml.

addresses issue #36 
