### PR TITLE
Add file exist check for pcapFile

### DIFF
--- a/sensor/pcap_agent.tcl
+++ b/sensor/pcap_agent.tcl
@@ -427,7 +427,7 @@ proc MergePcapFiles { rawDataFileName TRANS_ID type } {
         # Strip the 24 byte pcap header from all but the first file and append them to the main
         foreach pcapFile [lrange $PCAP_FILE_TRACKER($rawDataFileName) 1 end] {
 
-            if { [file size $pcapFile] > 24 } { 
+            if { [file exists $pcapFile] && if { [file size $pcapFile] > 24 } { 
 
                 set pID [open $pcapFile r]
                 fconfigure $pID -translation binary


### PR DESCRIPTION
There are times where the pcap-agent loses track of files.
This makes sure the pcap-agent won't try to open files that do not
exist, which causes the pcap-agent to crash.
