### PR TITLE
Fixup for IE browser

### DIFF
--- a/server/lib/SguildHttpsd.tcl
+++ b/server/lib/SguildHttpsd.tcl
@@ -7,6 +7,11 @@ proc SguildGetContentType { filepath } {
 
     set m [fileutil::magic::mimetype $filepath]
 
+    # Fixup for weird magic detection causing file download on IE
+    if { $m == "{exported SGML document text}"  } {
+        set m "text/html"
+    }
+
     # If fileutil can't determine the type, then try by extension.
     # We only server css, js, images
     if { $m == "" } {


### PR DESCRIPTION
Hello, 

Running on my RedHat 7 system the web server returns a weird content type for the root file ( index.html ). Since that, Internet explorer propose to download the file render the gui unusuable with Internet explorer. 

This simple fixup override the content type and fix this issues

