### PR TITLE
IPv6 support for Sguil

### DIFF
--- a/client/lib/SguilAutoCat.tcl
+++ b/client/lib/SguilAutoCat.tcl
@@ -279,7 +279,7 @@ proc ValidateAutoCat { erase sensor sip sport dip dport proto sig status comment
 
     } 
 
-    if { $sip != "any" && $sip != "ANY" && [ip::version $sip] != 4 } { return -code error "Source IP is invalid." }
+    if { $sip != "any" && $sip != "ANY" && [ip::version $sip] != 4 && [ip::version $sip] != 6 } { return -code error "Source IP is invalid." }
 
     if { $sensor == "" } { return -code error "Sensor cannot be left blank" }
 
@@ -287,7 +287,7 @@ proc ValidateAutoCat { erase sensor sip sport dip dport proto sig status comment
         return -code error "Source Port is invalid."
     }
     
-    if { $dip != "any" && $dip != "ANY" && [ip::version $dip] != 4 } { return -code error "Destination IP is invalid." }
+    if { $dip != "any" && $dip != "ANY" && [ip::version $dip] != 4 && [ip::version $dip] != 6 } { return -code error "Destination IP is invalid." }
 
     if { $dport != "any" && $dport != "ANY" && ($dport < 0 || $dport > 65535) } { 
         return -code error "Destination Port is invalid."

--- a/client/lib/extdata.tcl
+++ b/client/lib/extdata.tcl
@@ -456,7 +456,9 @@ proc GetHostbyAddr { ip } {
                 foreach homeNet $HOME_NET {
 
                     set netMask [ip::mask $homeNet]
-                    if { [ip::equal ${ip}/${netMask} $homeNet] } { set nameserver local }
+		    if { [ip::version $ip] == [ip::version $homeNet] } {
+                        if { [ip::equal ${ip}/${netMask} $homeNet] } { set nameserver local }
+		    }
 
                 }
 

--- a/client/lib/qrylib.tcl
+++ b/client/lib/qrylib.tcl
@@ -13,22 +13,22 @@ proc QueryRequest { tableName queryType { incidentCat {NULL} } { build {"build"}
     # (
     #
     #   SELECT sensor.hostname, sancp.sancpid, sancp.start_time as datetime, sancp.end_time, 
-    #          INET_NTOA(sancp.src_ip), sancp.src_port, INET_NTOA(sancp.dst_ip), sancp.dst_port,
+    #          INET6_NTOA(sancp.src_ip), sancp.src_port, INET6_NTOA(sancp.dst_ip), sancp.dst_port,
     #          sancp.ip_proto, sancp.src_pkts, sancp.src_bytes, sancp.dst_pkts, sancp.dst_bytes
     #   FROM sancp
     #   IGNORE INDEX (p_key) 
     #   INNER JOIN sensor ON sancp.sid=sensor.sid
-    #   WHERE sancp.start_time > '2005-08-02' AND sancp.src_ip = INET_ATON('82.96.96.3')
+    #   WHERE sancp.start_time > '2005-08-02' AND sancp.src_ip = INET6_ATON('82.96.96.3')
     #
     # ) UNION (
     #
     #   SELECT sensor.hostname, sancp.sancpid, sancp.start_time as datetime, sancp.end_time,
-    #          INET_NTOA(sancp.src_ip), sancp.src_port, INET_NTOA(sancp.dst_ip), sancp.dst_port,
+    #          INET6_NTOA(sancp.src_ip), sancp.src_port, INET6_NTOA(sancp.dst_ip), sancp.dst_port,
     #          sancp.ip_proto, sancp.src_pkts, sancp.src_bytes, sancp.dst_pkts, sancp.dst_bytes
     #   FROM sancp
     #   IGNORE INDEX (p_key)
     #   INNER JOIN sensor ON sancp.sid=sensor.sid
-    #   WHERE sancp.start_time > '2005-08-02' AND sancp.dst_ip = INET_ATON('82.96.96.3')
+    #   WHERE sancp.start_time > '2005-08-02' AND sancp.dst_ip = INET6_ATON('82.96.96.3')
     #
     # ) 
     #
@@ -96,12 +96,12 @@ proc QueryRequest { tableName queryType { incidentCat {NULL} } { build {"build"}
 
         if { $tableName == "pads" } {
 
-            lappend whereTmp "$globalWhere $tableName.ip = INET_ATON('$srcIP')"
+            lappend whereTmp "$globalWhere $tableName.ip = INET6_ATON('$srcIP')"
 
         } else {
 
-	    lappend whereTmp "$globalWhere $tableName.src_ip = INET_ATON('$srcIP')"
-            lappend whereTmp "$globalWhere $tableName.dst_ip = INET_ATON('$srcIP')"
+	    lappend whereTmp "$globalWhere $tableName.src_ip = INET6_ATON('$srcIP')"
+            lappend whereTmp "$globalWhere $tableName.dst_ip = INET6_ATON('$srcIP')"
 
         }
 
@@ -149,12 +149,12 @@ proc QueryRequest { tableName queryType { incidentCat {NULL} } { build {"build"}
 
         if { $tableName == "pads" } {
 
-            lappend whereTmp "$globalWhere $tableName.ip = INET_ATON('$dstIP')"
+            lappend whereTmp "$globalWhere $tableName.ip = INET6_ATON('$dstIP')"
 
         } else {
 
-	    lappend whereTmp "$globalWhere $tableName.src_ip = INET_ATON('$dstIP')"
-            lappend whereTmp "$globalWhere $tableName.dst_ip = INET_ATON('$dstIP')"
+	    lappend whereTmp "$globalWhere $tableName.src_ip = INET6_ATON('$dstIP')"
+            lappend whereTmp "$globalWhere $tableName.dst_ip = INET6_ATON('$dstIP')"
 
         }
 
@@ -176,7 +176,7 @@ proc QueryRequest { tableName queryType { incidentCat {NULL} } { build {"build"}
 
         }
 
-	lappend whereTmp "$globalWhere $tableName.src_ip  = INET_ATON('$srcIP') AND $tableName.dst_ip = INET_ATON('$dstIP')"
+	lappend whereTmp "$globalWhere $tableName.src_ip  = INET6_ATON('$srcIP') AND $tableName.dst_ip = INET6_ATON('$dstIP')"
 
     } elseif { $queryType == "category" } {
 
@@ -256,7 +256,7 @@ proc SsnQueryRequest { whereStatement } {
   global CONNECTED
   if {!$CONNECTED} {ErrorMessage "Not connected to sguild. Query aborted"; return}
   set selectQuery "SELECT sensor.hostname, sessions.xid, sessions.start_time, sessions.end_time,\
-   INET_NTOA(sessions.src_ip), sessions.src_port, INET_NTOA(sessions.dst_ip), sessions.dst_port,\
+   INET6_NTOA(sessions.src_ip), sessions.src_port, INET6_NTOA(sessions.dst_ip), sessions.dst_port,\
    sessions.ip_proto, sessions.src_pckts, sessions.src_bytes, sessions.dst_pckts, sessions.dst_bytes\
    FROM sessions INNER JOIN sensor ON sessions.sid=sensor.sid $whereStatement"
   regsub -all {\n} $selectQuery {} selectQuery
@@ -306,7 +306,7 @@ proc DBQueryRequest { selectedTable whereList {winTitle {none} } } {
   
     set COLUMNS "event.status, event.priority, sensor.hostname, \
      event.timestamp as datetime, event.sid, event.cid, event.signature,\
-     INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto,\
+     INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto,\
      event.src_port, event.dst_port, event.signature_gen, event.signature_id, \
      event.signature_rev"
 
@@ -411,7 +411,7 @@ proc PadsQueryRequest { table where } {
     if {!$CONNECTED} {ErrorMessage "Not connected to sguild. Query aborted"; return}
 
     set COLUMNS "pads.hostname, pads.sid, pads.asset_id, pads.timestamp as datetime, \
-     INET_NTOA(pads.ip), pads.ip_proto, pads.service, pads.port, pads.application"
+     INET6_NTOA(pads.ip), pads.ip_proto, pads.service, pads.port, pads.application"
 
     set tmpQuery "SELECT $COLUMNS FROM pads [lindex $where 0]"
     regsub -all {\n} $tmpQuery {} selectQuery

--- a/client/lib/sancp.tcl
+++ b/client/lib/sancp.tcl
@@ -9,7 +9,7 @@ proc SancpQueryRequest { selectedTable whereList } {
     if {!$CONNECTED} {ErrorMessage "Not connected to sguild. Query aborted"; return}
 
     set COLUMNS "sensor.hostname, sancp.sid, sancp.sancpid, sancp.start_time as datetime,\
-     sancp.end_time, INET_NTOA(sancp.src_ip), sancp.src_port, INET_NTOA(sancp.dst_ip),\
+     sancp.end_time, INET6_NTOA(sancp.src_ip), sancp.src_port, INET6_NTOA(sancp.dst_ip),\
      sancp.dst_port, sancp.ip_proto, sancp.src_pkts, sancp.src_bytes, sancp.dst_pkts,\
      sancp.dst_bytes"
 

--- a/client/sguil.tk
+++ b/client/sguil.tk
@@ -2203,7 +2203,7 @@ source $SGUILLIB/SguilAutoCat.tcl
 source $SGUILLIB/SguilElasticSearch.tcl
 
 # Load TableList
-package require tablelist 5.14
+package require tablelist
 
 # Images for tablelist checkbuttons
 if { [file exists $SGUILLIB/images/checked.gif] } {

--- a/sensor/pcap_agent.tcl
+++ b/sensor/pcap_agent.tcl
@@ -446,7 +446,7 @@ proc MergePcapFiles { rawDataFileName TRANS_ID type } {
         # Strip the 24 byte pcap header from all but the first file and append them to the main
         foreach pcapFile [lrange $PCAP_FILE_TRACKER($rawDataFileName) 1 end] {
 
-            if { [file size $pcapFile] > 24 } { 
+            if { [file exists $pcapFile] && [file size $pcapFile] > 24 } {
 
                 set pID [open $pcapFile r]
                 fconfigure $pID -translation binary

--- a/sensor/pcap_agent.tcl
+++ b/sensor/pcap_agent.tcl
@@ -381,11 +381,11 @@ proc CreateRawDataFile { TRANS_ID timestamp srcIP srcPort dstIP dstPort proto ra
         # Use ip or vlan for the filter
         if {$proto != "6" && $proto != "17"} {
 
-            set tcpdumpFilter "(ip and host $srcIP and host $dstIP and proto $proto) or (vlan and host $srcIP and host $dstIP and proto $proto)"
+            set tcpdumpFilter "((ip or ip6) and host $srcIP and host $dstIP and proto $proto) or (vlan and host $srcIP and host $dstIP and proto $proto)"
 
         } else {
 
-            set tcpdumpFilter "(ip and host $srcIP and host $dstIP and port $srcPort and port $dstPort and proto $proto) or (vlan and host $srcIP and host $dstIP and port $srcPort and port $dstPort and proto $proto)"
+            set tcpdumpFilter "((ip or ip6) and host $srcIP and host $dstIP and port $srcPort and port $dstPort and proto $proto) or (vlan and host $srcIP and host $dstIP and port $srcPort and port $dstPort and proto $proto)"
 
         }
 

--- a/server/contrib/incident_report.tcl
+++ b/server/contrib/incident_report.tcl
@@ -485,7 +485,7 @@ foreach status "11 12 13 14 15 16 17" {
         }
 
         set tmpQuery \
-            "SELECT COUNT(signature), INET_NTOA(src_ip), signature_id, signature \
+            "SELECT COUNT(signature), INET6_NTOA(src_ip), signature_id, signature \
              FROM event \
              WHERE $WHERE \
              GROUP BY signature, src_ip \
@@ -531,9 +531,9 @@ foreach status "11 12 13 14 15 16 17" {
         #################
 
         if { $status == 15 && $CHAT } {
-            set HOME_NET_CONSTR "src_ip >= INET_ATON('$HOME_NET_START') AND src_ip <= INET_ATON('$HOME_NET_END')"
+            set HOME_NET_CONSTR "src_ip >= INET6_ATON('$HOME_NET_START') AND src_ip <= INET6_ATON('$HOME_NET_END')"
             set tmpQuery \
-                "SELECT COUNT(signature) as sCount, INET_NTOA(src_ip), signature_id, signature \
+                "SELECT COUNT(signature) as sCount, INET6_NTOA(src_ip), signature_id, signature \
                  FROM event \
                  WHERE timestamp $TIMECONSTR AND status=15 AND signature LIKE 'CHAT%' AND $HOME_NET_CONSTR \
                  GROUP BY signature, src_ip \

--- a/server/html/sguilclient/controllers.js
+++ b/server/html/sguilclient/controllers.js
@@ -1592,9 +1592,9 @@ angular.module('MainConsole', ['material.svgAssetsCache', 'luegg.directives', 'u
             $scope.eventWhere = 'WHERE event.timestamp > \'' + date + '\'';
 
             if (type === "src_ip") {
-                $scope.eventWhere += ' AND event.src_ip = INET_ATON(\''+ data.src_ip + '\')';
+                $scope.eventWhere += ' AND event.src_ip = INET6_ATON(\''+ data.src_ip + '\')';
             } else if (type === "dest_ip") {
-                $scope.eventWhere += ' AND event.dst_ip = INET_ATON(\''+ data.dest_ip + '\')';
+                $scope.eventWhere += ' AND event.dst_ip = INET6_ATON(\''+ data.dest_ip + '\')';
             } else if (type === "signature") {
                 $scope.eventWhere += ' AND event.signature = \''+ data.msg + '\'';
             } else {
@@ -1642,8 +1642,8 @@ angular.module('MainConsole', ['material.svgAssetsCache', 'luegg.directives', 'u
                                 event.sid, \
                                 event.cid, \
                                 event.signature, \
-                                INET_NTOA(event.src_ip), \
-                                INET_NTOA(event.dst_ip), \
+                                INET6_NTOA(event.src_ip), \
+                                INET6_NTOA(event.dst_ip), \
                                 event.ip_proto, \
                                 event.src_port, \
                                 event.dst_port, \
@@ -1667,7 +1667,7 @@ angular.module('MainConsole', ['material.svgAssetsCache', 'luegg.directives', 'u
                 });
 
             /*
-            2017-04-20 02:40:54 pid(14755)  Client Command Received: QueryDB .eventPane.pane0.childsite.eventTabs.canvas.notebook.cs.page3.cs.query_1.tablelist {( SELECT event.status, event.priority, sensor.hostname,  event.timestamp as datetime, event.sid, event.cid, event.signature, INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto, event.src_port, event.dst_port, event.signature_gen, event.signature_id,  event.signature_rev FROM event IGNORE INDEX (event_p_key, sid_time) INNER JOIN sensor ON event.sid=sensor.sid WHERE event.timestamp > '2017-04-12' AND  event.src_ip = INET_ATON('59.45.175.62') ) UNION ( SELECT event.status, event.priority, sensor.hostname,  event.timestamp as datetime, event.sid, event.cid, event.signature, INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto, event.src_port, event.dst_port, event.signature_gen, event.signature_id,  event.signature_rev FROM event IGNORE INDEX (event_p_key, sid_time) INNER JOIN sensor ON event.sid=sensor.sid WHERE event.timestamp > '2017-04-12' AND  event.dst_ip = INET_ATON('59.45.175.62') ) ORDER BY datetime, src_port ASC LIMIT 1000}
+            2017-04-20 02:40:54 pid(14755)  Client Command Received: QueryDB .eventPane.pane0.childsite.eventTabs.canvas.notebook.cs.page3.cs.query_1.tablelist {( SELECT event.status, event.priority, sensor.hostname,  event.timestamp as datetime, event.sid, event.cid, event.signature, INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto, event.src_port, event.dst_port, event.signature_gen, event.signature_id,  event.signature_rev FROM event IGNORE INDEX (event_p_key, sid_time) INNER JOIN sensor ON event.sid=sensor.sid WHERE event.timestamp > '2017-04-12' AND  event.src_ip = INET6_ATON('59.45.175.62') ) UNION ( SELECT event.status, event.priority, sensor.hostname,  event.timestamp as datetime, event.sid, event.cid, event.signature, INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto, event.src_port, event.dst_port, event.signature_gen, event.signature_id,  event.signature_rev FROM event IGNORE INDEX (event_p_key, sid_time) INNER JOIN sensor ON event.sid=sensor.sid WHERE event.timestamp > '2017-04-12' AND  event.dst_ip = INET6_ATON('59.45.175.62') ) ORDER BY datetime, src_port ASC LIMIT 1000}
             */
 
         }

--- a/server/lib/SguildAutoCat.tcl
+++ b/server/lib/SguildAutoCat.tcl
@@ -20,6 +20,7 @@
 #  | comment    | varchar(255)         | YES  |     | NULL    |                |
 #  +------------+----------------------+------+-----+---------+----------------+
 
+package require ip
 
 # Return a list of all autocats in the DB
 proc GetAutoCatList {} {
@@ -197,7 +198,7 @@ proc AddAutoCatRule { rid rList } {
 
 	    # IP is valid and now we have a list with our ip range (net number - bcast address)
 	    # if it was a single address and not a net, these numbers will be the same
-	    set tmpVar [list [InetAtoN [lindex $ipList 2]] [InetAtoN [lindex $ipList 3]]]
+	    set tmpVar [list [ip::normalize [lindex $ipList 2]] [ip::normalize [lindex $ipList 3]]]
 
 	}
 	
@@ -232,8 +233,8 @@ proc AutoCat { data } {
 	    } elseif { $rIndex != 7 } {
 		# ip address match vars are a list with a low and high ip address
 		set dataVar [InetAtoN [lindex $data $rIndex]]
-		set netIP [lindex $rMatch 0]
-		set bcastIP [lindex $rMatch 1]
+		set netIP [InetAtoN [lindex $rMatch 0]]
+		set bcastIP [InetAtoN [lindex $rMatch 1]]
 		if { $dataVar < $netIP || $dataVar > $bcastIP } {
 		    set MATCH 0
                     break

--- a/server/lib/SguildClientCmdRcvd.tcl
+++ b/server/lib/SguildClientCmdRcvd.tcl
@@ -339,7 +339,7 @@ proc GetSancpFlagData { socketID sensorID xid } {
 }
 proc GetIPData { socketID sid cid } {
   set query\
-   "SELECT INET_NTOA(src_ip), INET_NTOA(dst_ip), ip_ver, ip_hlen, ip_tos, ip_len, ip_id,\
+   "SELECT INET6_NTOA(src_ip), INET6_NTOA(dst_ip), ip_ver, ip_hlen, ip_tos, ip_len, ip_id,\
     ip_flags, ip_off, ip_ttl, ip_csum\
    FROM event\
    WHERE sid=$sid and cid=$cid"
@@ -404,7 +404,7 @@ proc GetOpenPorts { socketID sid cid } {
 	return
     }
     set query\
-	"SELECT INET_NTOA(event.dst_ip), data.data_payload from event, data WHERE event.sid=data.sid AND event.cid=data.cid AND event.unified_event_ref=$event_id"
+	"SELECT INET6_NTOA(event.dst_ip), data.data_payload from event, data WHERE event.sid=data.sid AND event.cid=data.cid AND event.unified_event_ref=$event_id"
     foreach row [mysqlsel $dbSocketID "$query" -list] {
     catch {SendSocket $socketID [list InsertOpenPortsData $row]} tmpError
     }

--- a/server/lib/SguildEvent.tcl
+++ b/server/lib/SguildEvent.tcl
@@ -190,7 +190,7 @@ proc DeleteEventIDList { socketID status comment eidList } {
             } else {
 
                 set escalateArray($tmpEid) [FlatDBQuery\
-                 "SELECT 2, event.priority, event.class, sensor.hostname, event.timestamp, event.sid, event.cid, event.signature, INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto, event.src_port, event.dst_port FROM event, sensor WHERE event.sid=sensor.sid AND event.sid=[lindex [split $tmpEid .] 0] AND event.cid=[lindex [split $tmpEid .] 1]"]
+                 "SELECT 2, event.priority, event.class, sensor.hostname, event.timestamp, event.sid, event.cid, event.signature, INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto, event.src_port, event.dst_port FROM event, sensor WHERE event.sid=sensor.sid AND event.sid=[lindex [split $tmpEid .] 0] AND event.cid=[lindex [split $tmpEid .] 1]"]
 
             }
 

--- a/server/lib/SguildGenericDB.tcl
+++ b/server/lib/SguildGenericDB.tcl
@@ -236,10 +236,10 @@ proc InsertEventHdr { tablePostfix sid cid u_event_id u_event_ref u_ref_time msg
     set tmpValues \
          "'$sid', '$cid', '$u_event_id', '$u_event_ref', '$u_ref_time', '[mysqlescape $msg]',  \
          '$sig_gen', '$sig_id', '$sig_rev', '$timestamp', '$priority',   \
-         '$class_type', '$status', '$dec_sip', '$dec_dip', '$ip_proto',  \
+         '$class_type', '$status', INET6_ATON('$dec_sip'), INET6_ATON('$dec_dip'), '$ip_proto',  \
          '$ip_ver', '$ip_hlen', '$ip_tos', '$ip_len', '$ip_id',          \
          '$ip_flags', '$ip_off', '$ip_ttl', '$ip_csum'"
-                                                                                                                       
+
     # ICMP, TCP, & UDP have extra columns
     if { $ip_proto == "1" } {
                                                                                                                        

--- a/server/lib/SguildGenericEvent.tcl
+++ b/server/lib/SguildGenericEvent.tcl
@@ -29,9 +29,7 @@ proc GenericEvent { agentSocketID eventList } {
     set refID [lindex $eventList 7]
     set msg [hex2string [lindex $eventList 8]]
     set inet_sip [lindex $eventList 9]
-    set dec_sip [InetAtoN $inet_sip]
     set inet_dip [lindex $eventList 10]
-    set dec_dip [InetAtoN $inet_dip]
     set ip_proto [lindex $eventList 11]
     set src_port [lindex $eventList 12]
     set dst_port [lindex $eventList 13]
@@ -46,8 +44,8 @@ proc GenericEvent { agentSocketID eventList } {
 
     # Insert data into the event hdr
     if [catch { InsertEventHdr $tablePrefix $sensorID $alertID $alertID $refID $timestamp \
-                $msg $gen_id $sig_id $revision $timestamp $priority $class $status $dec_sip \
-                $dec_dip $ip_proto {} {} {} {} {} {} {} {} {} {} {} $src_port $dst_port } tmpError] {
+                $msg $gen_id $sig_id $revision $timestamp $priority $class $status $inet_sip \
+                $inet_dip $ip_proto {} {} {} {} {} {} {} {} {} {} {} $src_port $dst_port } tmpError] {
 
         # DEBUG Foo
         LogMessage "ERROR: While inserting event info: $tmpError"

--- a/server/lib/SguildHttpsd.tcl
+++ b/server/lib/SguildHttpsd.tcl
@@ -5,25 +5,16 @@ proc HttpDate { secs } {
 
 proc SguildGetContentType { filepath } {
 
-    set m [fileutil::magic::mimetype $filepath]
+    set ext [file extension $filepath]
 
-    # If fileutil can't determine the type, then try by extension.
-    # We only server css, js, images
-    if { $m == "" } {
+    switch -exact $ext {
 
-        set ext [file extension $filepath]
-
-        switch -exact $ext {
-
-            ".css"	{ set m "text/css" }
-            ".js"	{ set m "text/javascript" }
-            ".svg"	{ set m "image/svg+xml" }
-            default	{ }
-
-        }
+        ".css"	{ set m "text/css" }
+        ".js"	{ set m "text/javascript" }
+        ".svg"	{ set m "image/svg+xml" }
+        default	{ }
 
     }
-
     return $m
 
 }

--- a/server/lib/SguildLoaderd.tcl
+++ b/server/lib/SguildLoaderd.tcl
@@ -108,9 +108,9 @@ proc CreateNewSancpTable { tableName } {
         end_time      DATETIME                NOT NULL,    \
         duration      INT UNSIGNED            NOT NULL,    \
         ip_proto      TINYINT UNSIGNED        NOT NULL,    \
-        src_ip        INT UNSIGNED,                        \
+        src_ip        VARBINARY(16),                       \
         src_port      SMALLINT UNSIGNED,                   \
-        dst_ip        INT UNSIGNED,                        \
+        dst_ip        VARBINARY(16),                       \
         dst_port      SMALLINT UNSIGNED,                   \
         src_pkts      INT UNSIGNED            NOT NULL,    \
         src_bytes     INT UNSIGNED            NOT NULL,    \
@@ -161,9 +161,9 @@ proc CreateSancpMergeTable { dbSocketID } {
         end_time      DATETIME                NOT NULL,    \
         duration      INT UNSIGNED            NOT NULL,    \
         ip_proto      TINYINT UNSIGNED        NOT NULL,    \
-        src_ip        INT UNSIGNED,                        \
+        src_ip        VARBINARY(16),                       \
         src_port      SMALLINT UNSIGNED,                   \
-        dst_ip        INT UNSIGNED,                        \
+        dst_ip        VARBINARY(16),                       \
         dst_port      SMALLINT UNSIGNED,                   \
         src_pkts      INT UNSIGNED            NOT NULL,    \
         src_bytes     INT UNSIGNED            NOT NULL,    \
@@ -241,12 +241,18 @@ proc LoadFile { fileName table } {
     }
 
     if { $DBHOST != "localhost" && $DBHOST != "127.0.0.1" } {
-        set dbCmd "LOAD DATA CONCURRENT LOCAL INFILE '$fileName' INTO TABLE `$table`\
-                   FIELDS TERMINATED BY '|'"
+        set dbCmd "LOAD DATA CONCURRENT LOCAL INFILE '$fileName' INTO TABLE `$table` \
+                   FIELDS TERMINATED BY '|' \
+		   (sid, sancpid, start_time, end_time, duration, ip_proto, @var8, src_port, \
+		   @var10, dst_port, src_pkts, src_bytes, dst_pkts, dst_bytes, src_flags, dst_flags) \
+		   SET src_ip = INET6_ATON(@var8), dst_ip = INET6_ATON(@var10)"
     } else {
         #set dbCmd "LOAD DATA CONCURRENT INFILE '$fileName' INTO TABLE `$table`
-        set dbCmd "LOAD DATA CONCURRENT LOCAL INFILE '$fileName' INTO TABLE `$table`\
-                   FIELDS TERMINATED BY '|'"
+        set dbCmd "LOAD DATA CONCURRENT LOCAL INFILE '$fileName' INTO TABLE `$table` \
+                   FIELDS TERMINATED BY '|' \
+		   (sid, sancpid, start_time, end_time, duration, ip_proto, @var8, src_port, \
+		   @var10, dst_port, src_pkts, src_bytes, dst_pkts, dst_bytes, src_flags, dst_flags) \
+		   SET src_ip = INET6_ATON(@var8), dst_ip = INET6_ATON(@var10)"
     }
 
     if [catch {mysqlexec $LOADERD_DB_ID $dbCmd} execResults] {

--- a/server/lib/SguildMysqlMerge.tcl
+++ b/server/lib/SguildMysqlMerge.tcl
@@ -88,8 +88,8 @@ proc CreateMysqlMainEventMergeTable {} {
         priority              INT UNSIGNED,                     \
         class                 VARCHAR(20),                      \
         status                SMALLINT UNSIGNED DEFAULT 0,      \
-        src_ip                INT UNSIGNED,                     \
-        dst_ip                INT UNSIGNED,                     \
+        src_ip                VARBINARY(16),                    \
+        dst_ip                VARBINARY(16),                    \
         src_port              INT UNSIGNED,                     \
         dst_port              INT UNSIGNED,                     \
         icmp_type             TINYINT UNSIGNED,                 \
@@ -288,8 +288,8 @@ proc CreateEventTable { tableName } {
         priority              INT UNSIGNED,                     \
         class                 VARCHAR(20),                      \
         status                SMALLINT UNSIGNED DEFAULT 0,      \
-        src_ip                INT UNSIGNED,                     \
-        dst_ip                INT UNSIGNED,                     \
+        src_ip                VARBINARY(16),                    \
+        dst_ip                VARBINARY(16),                    \
         src_port              INT UNSIGNED,                     \
         dst_port              INT UNSIGNED,                     \
         icmp_type             TINYINT UNSIGNED,                 \

--- a/server/lib/SguildReportBuilder.tcl
+++ b/server/lib/SguildReportBuilder.tcl
@@ -39,7 +39,7 @@ proc ReportBuilder { socketID type sid cid } {
         }
        IP {
             set query\
-                "SELECT INET_NTOA(src_ip), INET_NTOA(dst_ip), ip_ver, ip_hlen, ip_tos, ip_len, ip_id,\
+                "SELECT INET6_NTOA(src_ip), INET6_NTOA(dst_ip), ip_ver, ip_hlen, ip_tos, ip_len, ip_id,\
                 ip_flags, ip_off, ip_ttl, ip_csum\
                 FROM event\
                 WHERE sid=$sid and cid=$cid"

--- a/server/lib/SguildSensorAgentComms.tcl
+++ b/server/lib/SguildSensorAgentComms.tcl
@@ -133,7 +133,7 @@ proc BYEventRcvd { socketID req_socketID status sid cid sensorName u_event_id   
     # Insert Event Hdr
     if [catch { InsertEventHdr $tablePrefix $sid $cid $u_event_id $u_event_ref $u_ref_time \
                 $msg $sig_gen $sig_id $sig_rev $timestamp $priority $class_type \
-                $status $dec_sip $dec_dip $ip_proto $ip_ver $ip_hlen $ip_tos \
+                $status $str_sip $str_dip $ip_proto $ip_ver $ip_hlen $ip_tos \
                 $ip_len $ip_id $ip_flags $ip_off $ip_ttl $ip_csum $icmp_type \
                 $icmp_code $src_port $dst_port } tmpError] {
 

--- a/server/lib/SguildUtils.tcl
+++ b/server/lib/SguildUtils.tcl
@@ -186,14 +186,17 @@ proc ValidateIPAddress { fullip } {
 #
 proc InetAtoN { ipaddress } {
 
-    if { $ipaddress == "" } { return "" }
-    set octetlist [split $ipaddress "."]
-    set oct1 [lindex $octetlist 0]
-    set oct2 [lindex $octetlist 1]
-    set oct3 [lindex $octetlist 2]
-    set oct4 [lindex $octetlist 3]
-    set decIP [expr ($oct1 * 16777216.0) + ($oct2 * 65536.0) + ($oct3 * 256.0) + $oct4]
-    return $decIP
+    if { $ipaddress == "" } { return 0 }
+    package require ip
+    set ipv [ip::version $ipaddress]
+    if { $ipv == 4 } {
+      set normalized [format %08x [ip::toInteger $ipaddress]]
+    } else {
+      set normalized [string map {: ""} [ip::normalize $ipaddress]]
+    }
+
+    set decIP [binary decode hex $normalized]
+    return $ipaddress
 }
 
 proc GetCurrentTimeStamp {} {

--- a/server/sguild
+++ b/server/sguild
@@ -764,7 +764,7 @@ if { $mergeTableListArray(event) != "" } {
 
         set tmpQry "SELECT event.status, event.priority, event.class, sensor.hostname,       \n\
                     event.timestamp, event.sid, event.cid, event.signature,                  \n\
-                    INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto,        \n\
+                    INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto,      \n\
                     event.src_port, event.dst_port, event.signature_gen, event.signature_id, \n\
                     event.signature_rev, event.unified_event_id, unified_event_ref           \n\
                     FROM event                                                               \n\
@@ -776,7 +776,7 @@ if { $mergeTableListArray(event) != "" } {
 
         set tmpQry "SELECT event.status, event.priority, event.class, sensor.hostname,       \n\
                     event.timestamp, event.sid, event.cid, event.signature,                  \n\
-                    INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto,        \n\
+                    INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto,      \n\
                     event.src_port, event.dst_port, event.signature_gen, event.signature_id, \n\
                     event.signature_rev, event.unified_event_id, unified_event_ref           \n\
                     FROM event, sensor                                                       \n\
@@ -819,7 +819,7 @@ if { $mergeTableListArray(event) != "" } {
 
         set tmpQry "SELECT event.status, event.priority, event.class, sensor.hostname,      \n\
                     event.timestamp, event.sid, event.cid, event.signature,                 \n\
-                    INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto,       \n\
+                    INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto,     \n\
                     event.src_port, event.dst_port, event.signature_gen,                    \n\
                     event.signature_id, event.signature_rev                                 \n\
                     FROM event                                                              \n\
@@ -831,7 +831,7 @@ if { $mergeTableListArray(event) != "" } {
 
         set tmpQry "SELECT event.status, event.priority, event.class, sensor.hostname,      \n\
                     event.timestamp, event.sid, event.cid, event.signature,                 \n\
-                    INET_NTOA(event.src_ip), INET_NTOA(event.dst_ip), event.ip_proto,       \n\
+                    INET6_NTOA(event.src_ip), INET6_NTOA(event.dst_ip), event.ip_proto,     \n\
                     event.src_port, event.dst_port, event.signature_gen,                    \n\
                     event.signature_id, event.signature_rev                                 \n\
                     FROM event                                                              \n\
@@ -911,7 +911,7 @@ if { [info exists HTTPS] && $HTTPS } {
   if { ![file exists $HTML_PATH] } { ErrorMessage "Error: HTTP configured by HTML_PATH ($HTML_PATH) does not exist." }
   if { ![info exists HTTPS_PORT] || $HTTPS_PORT == "" } { set HTTPS_PORT 443 }
   
-  foreach p [list uri base64 fileutil::magic::mimetype websocket json json::write] {
+  foreach p [list uri base64 websocket json json::write] {
     if [catch {package require $p} pVersion] {
         ErrorMessage "Error: Failed to load package $p. $p is required for HTTPS/WSS."
     }

--- a/server/sguild.reports
+++ b/server/sguild.reports
@@ -23,9 +23,9 @@ CATCOUNT||Counts of Events by Category||query||SELECT status.description, COUNT(
 
 TOPTEN||Top Ten Events||query||SELECT count(event.signature) as Count, event.signature from event, sensor WHERE event.sid = sensor.sid and %%SENSORS%% and event.timestamp > %%STARTTIME%% and event.timestamp < %%ENDTIME%% GROUP BY event.signature ORDER BY Count desc LIMIT 10||2||
 
-TOPTENSIP||Top Ten Source IP's||query||SELECT count(event.src_ip) as count, INET_NTOA(event.src_ip) FROM event, sensor WHERE event.sid = sensor.sid AND %%SENSORS%% AND event.timestamp > %%STARTTIME%% AND event.timestamp < %%ENDTIME%% GROUP BY event.src_ip order by count desc limit 10||2||
+TOPTENSIP||Top Ten Source IP's||query||SELECT count(event.src_ip) as count, INET6_NTOA(event.src_ip) FROM event, sensor WHERE event.sid = sensor.sid AND %%SENSORS%% AND event.timestamp > %%STARTTIME%% AND event.timestamp < %%ENDTIME%% GROUP BY event.src_ip order by count desc limit 10||2||
 
-TOPTENDIP||Top Ten Dest IP's||query||SELECT count(event.dst_ip) as count, INET_NTOA(event.dst_ip) FROM event, sensor WHERE event.sid = sensor.sid AND %%SENSORS%% AND event.timestamp > %%STARTTIME%% AND event.timestamp < %%ENDTIME%% GROUP BY event.dst_ip order by count desc limit 10||2||
+TOPTENDIP||Top Ten Dest IP's||query||SELECT count(event.dst_ip) as count, INET6_NTOA(event.dst_ip) FROM event, sensor WHERE event.sid = sensor.sid AND %%SENSORS%% AND event.timestamp > %%STARTTIME%% AND event.timestamp < %%ENDTIME%% GROUP BY event.dst_ip order by count desc limit 10||2||
 
 TOPTENSPORT||Top Ten Source Ports||query||SELECT count(event.src_port) as count, event.src_port FROM event, sensor WHERE event.sid = sensor.sid AND %%SENSORS%% AND event.timestamp > %%STARTTIME%% AND event.timestamp < %%ENDTIME%% GROUP BY event.src_port order by count desc limit 10||2||
 

--- a/server/sql_scripts/create_sguildb.sql
+++ b/server/sql_scripts/create_sguildb.sql
@@ -102,7 +102,7 @@ CREATE TABLE IF NOT EXISTS `pads`
   sid                   INT UNSIGNED     NOT NULL,
   asset_id              INT UNSIGNED     NOT NULL,
   timestamp             DATETIME         NOT NULL,
-  ip                    INT UNSIGNED     NOT NULL,
+  ip                    VARBINARY(16)    NOT NULL,
   service               VARCHAR(40)      NOT NULL,
   port                  INT UNSIGNED     NOT NULL,
   ip_proto              TINYINT UNSIGNED NOT NULL,

--- a/server/sql_scripts/create_sguildb.sql
+++ b/server/sql_scripts/create_sguildb.sql
@@ -13,20 +13,20 @@ CREATE TABLE sensor
   public_key	VARCHAR(255) DEFAULT NULL,
   PRIMARY KEY (sid),
   INDEX hostname_idx (hostname)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE portscan
 (
   hostname	VARCHAR(255),
   timestamp	DATETIME,
-  src_ip	VARCHAR(16),
+  src_ip	VARBINARY(16),
   src_port	INT UNSIGNED,
-  dst_ip	VARCHAR(16),
+  dst_ip	VARBINARY(16),
   dst_port	INT UNSIGNED,
   data		TEXT,
   INDEX ps_src_ip (src_ip),
   INDEX ps_timestamp (timestamp)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE status
 (
@@ -34,16 +34,16 @@ CREATE TABLE status
   description	VARCHAR(255) NOT NULL,
   long_desc     VARCHAR(255),
   PRIMARY KEY (status_id)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE autocat
 (
   autoid	INT UNSIGNED NOT NULL AUTO_INCREMENT,
   erase		DATETIME,
   sensorname	VARCHAR(255),
-  src_ip	VARCHAR(18),
+  src_ip	VARBINARY(16),
   src_port	INT UNSIGNED, 
-  dst_ip	VARCHAR(18),
+  dst_ip	VARBINARY(16),
   dst_port	INT UNSIGNED, 
   ip_proto	TINYINT UNSIGNED,
   signature	VARCHAR(255),
@@ -53,7 +53,7 @@ CREATE TABLE autocat
   uid		INT UNSIGNED	NOT NULL,
   comment	VARCHAR(255),
   PRIMARY KEY (autoid)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE history
 (
@@ -64,7 +64,7 @@ CREATE TABLE history
   status	SMALLINT UNSIGNED	NOT NULL,
   comment	VARCHAR(255),
   INDEX log_time (timestamp)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE user_info
 (
@@ -73,7 +73,7 @@ CREATE TABLE user_info
   last_login	DATETIME,
   password	VARCHAR(42),
   PRIMARY KEY (uid)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE nessus_data
 (
@@ -83,7 +83,7 @@ CREATE TABLE nessus_data
   level	        VARCHAR(20),
   description		TEXT,
   INDEX rid (rid)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE nessus
 (
@@ -94,7 +94,7 @@ CREATE TABLE nessus
   timeend       DATETIME,
   PRIMARY KEY (rid),
   INDEX ip (ip)
-) ENGINE = MYISAM;
+);
 
 CREATE TABLE IF NOT EXISTS `pads`
 (
@@ -109,7 +109,7 @@ CREATE TABLE IF NOT EXISTS `pads`
   application           VARCHAR(255)     NOT NULL,
   hex_payload           VARCHAR(255),
   PRIMARY KEY (sid,asset_id)
-) ENGINE = MYISAM;
+);
 
 INSERT INTO status (status_id, description, long_desc) VALUES (0, "New", "Real Time Event");
 INSERT INTO status (status_id, description, long_desc) VALUES (1, "No Further Action Required", "No Further Action Required");
@@ -127,6 +127,6 @@ CREATE TABLE version
 (
   version	VARCHAR(32),
   installed	DATETIME
-) ENGINE = MYISAM;
+);
 
 INSERT INTO version (version, installed) VALUES ("0.14", now());

--- a/server/sql_scripts/sancp_cleanup.tcl
+++ b/server/sql_scripts/sancp_cleanup.tcl
@@ -198,9 +198,9 @@ set createQuery "                                      \
     end_time      DATETIME                NOT NULL,    \
     duration      INT UNSIGNED            NOT NULL,    \
     ip_proto      TINYINT UNSIGNED        NOT NULL,    \
-    src_ip        INT UNSIGNED,                        \
+    src_ip        VARBINARY(16),                       \
     src_port      SMALLINT UNSIGNED,                   \
-    dst_ip        INT UNSIGNED,                        \
+    dst_ip        VARBINARY(16),                       \
     dst_port      SMALLINT UNSIGNED,                   \
     src_pkts      INT UNSIGNED            NOT NULL,    \
     src_bytes     INT UNSIGNED            NOT NULL,    \


### PR DESCRIPTION
Work was done on OpenBSD, so I've some unrelated patches in use as well to make it
integrate there as best as possible.


sguild server, sguil client, sensor scripts patched to handle IPv6 in addition to IPv4
	  - database schema updated to store IP addresses as varbinary(16)
	     - access IP addresses with INET6_NTOA/INET6_ATON everywhere
		 - no no database upgrade script
	  - sensors tested to be working:
	     - suricata_agent: works well
		 - snort_agent: retrieving logs from barnyard2 files, only IPv4, as I see it, it's a barnyard2 limitation
		 - sancp_agent: 
		    - sancp itself doesn't support IPv6, but I used it with cxtracker for my testing
		 - pads_agent: 
		    - pads itself doesn't support IPv6, but I used it with prads for my testing
		 - pcap_agent: seems to do the trick
	  - autocat seems to work as well
	     - however, my IPv6 patch made it require TCL 8.6
	  - what is not working IPv6 wise:
	     - reverse DNS lookups of IPv6 in sguil client
		    - it's not a problem in Sguil per-se, it's a limitation of tcllib, but should be easy
			  to make it work: https://core.tcl-lang.org/tcllib/tktview?name=8168daf796
         - transcript generation relies on tcpflow, however, the version on OpenBSD is quite
		   from the stone-age and doesn't support IPv6. A quick attempt to update it failed and I haven't yet bothered to look deeper into it.

Note: haven't looked at the ES integration part at all yet.
However, have patches for the security-onion fork of Squert to add IPv6 support there as well.