### PR TITLE
use ProcessAutoCat for removal instead of AddAutoCat

### DIFF
--- a/server/lib/SguildAutoCat.tcl
+++ b/server/lib/SguildAutoCat.tcl
@@ -318,8 +318,8 @@ proc AutoCatRequest { clientSocketID ruleList } {
         return
 
     }
-    
-    if { [catch {AddAutoCatRule $rid [lrange $ruleList 1 end]} tmpError] } {
+
+    if { [catch {ProcessAutoCat "$rid $ruleList"} tmpError] } {
 
         catch {SendSocket $clientSocketID [list ErrorMessage "Error inserting autocat rule: $rid"] 1} tmpError
 


### PR DESCRIPTION
AddAutoCat does not include a removal, so the autocat wont be removed until a restart (reloads autocat list and runs ProcessAutoCat)